### PR TITLE
cosmo: remove reflect calls in LambdaCDM benchmarks

### DIFF
--- a/benchmark_lambdacdm_test.go
+++ b/benchmark_lambdacdm_test.go
@@ -1,7 +1,6 @@
 package cosmo
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -24,7 +23,8 @@ func BenchmarkLambdaCDMEN(b *testing.B) {
 }
 
 func BenchmarkLambdaCDMENdistance(b *testing.B) {
-	benchmarkLambdaCDMNdistance(10000, "E", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMNdistance(10000, cos.E, b)
 }
 
 func BenchmarkLambdaCDME(b *testing.B) {
@@ -43,108 +43,78 @@ func BenchmarkLambdaCDMEinv(b *testing.B) {
 	}
 }
 
-// benchmarkLambdaCDMDistanceFlat is a helper function to be called by specific benchmarkLambdaCDMs
-//   for an Omega_K == 0 cosmology
-func benchmarkLambdaCDMDistanceFlat(distFunc string, b *testing.B) {
-	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.7}
-	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
-	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
-	}
-}
-
-// benchmarkLambdaCDMDistancePositiveOk0 is a helper function to be called by specific benchmarkLambdaCDMs
-//   for an Omega_K > 0 cosmology
-func benchmarkLambdaCDMDistancePositiveOk0(distFunc string, b *testing.B) {
-	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
-	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
-	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
-	}
-}
-
-// benchmarkLambdaCDMDistanceOM is a helper function to be called by specific benchmarkLambdaCDMs
-//   for an Omega_Lambda = 0 cosmology
-func benchmarkLambdaCDMDistanceOM(distFunc string, b *testing.B) {
-	cos := LambdaCDM{H0: 70, Om0: 0.27, Ol0: 0.}
-	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
-	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
-	}
-}
-
 // benchmarkLambdaCDMDistance is a helper function to be called by specific benchmarkLambdaCDMs
-func benchmarkLambdaCDMDistance(distFunc string, b *testing.B) {
-	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+func benchmarkLambdaCDMDistance(f func(float64) float64, b *testing.B) {
 	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
 	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
+		f(z)
 	}
 }
 
 // benchmarkLambdaCDMNdistance is a helper function to be called by specific benchmarkLambdaCDMs
-func benchmarkLambdaCDMNdistance(n int, distFunc string, b *testing.B) {
-	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
+func benchmarkLambdaCDMNdistance(n int, f func(float64) float64, b *testing.B) {
 	var z float64
 	zMax := 1.0
 	step := zMax / float64(n)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
 			z = 0.001 + step*float64(j)
-			funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
+			f(z)
 		}
 	}
 }
 
 func BenchmarkLambdaCDMComovingDistance(b *testing.B) {
-	benchmarkLambdaCDMDistance("ComovingDistance", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMDistance(cos.ComovingDistance, b)
 }
 
 func BenchmarkLambdaCDMComovingTransverseDistance(b *testing.B) {
-	benchmarkLambdaCDMDistance("ComovingTransverseDistance", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMDistance(cos.ComovingTransverseDistance, b)
 }
 
 func BenchmarkLambdaCDMLuminosityDistance(b *testing.B) {
-	benchmarkLambdaCDMDistance("LuminosityDistance", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMDistance(cos.LuminosityDistance, b)
 }
 
 func BenchmarkLambdaCDMLookbackTime(b *testing.B) {
-	benchmarkLambdaCDMDistance("LookbackTime", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMDistance(cos.LookbackTime, b)
 }
 
 func BenchmarkLambdaCDMNComovingDistance(b *testing.B) {
-	benchmarkLambdaCDMNdistance(10000, "ComovingDistance", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMNdistance(10000, cos.ComovingDistance, b)
 }
 
 func BenchmarkLambdaCDMNLuminosityDistance(b *testing.B) {
-	benchmarkLambdaCDMNdistance(10000, "LuminosityDistance", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMNdistance(10000, cos.LuminosityDistance, b)
 }
 
 func BenchmarkLambdaCDMNE(b *testing.B) {
-	benchmarkLambdaCDMNdistance(10000, "E", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMNdistance(10000, cos.E, b)
 }
 
 func BenchmarkLambdaCDMComovingDistanceOM(b *testing.B) {
-	benchmarkLambdaCDMDistanceOM("ComovingDistance", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.27, Ol0: 0.}
+	benchmarkLambdaCDMDistance(cos.ComovingDistance, b)
 }
 
 func BenchmarkLambdaCDMLookbackTimeOM(b *testing.B) {
-	benchmarkLambdaCDMDistanceOM("LookbackTime", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.27, Ol0: 0.}
+	benchmarkLambdaCDMDistance(cos.LookbackTime, b)
 }
 
 func BenchmarkLambdaCDMComovingDistanceFlat(b *testing.B) {
-	benchmarkLambdaCDMDistanceFlat("ComovingDistance", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.7}
+	benchmarkLambdaCDMDistance(cos.ComovingDistance, b)
 }
 
 func BenchmarkLambdaCDMComovingDistancePositiveOk0(b *testing.B) {
-	benchmarkLambdaCDMDistancePositiveOk0("ComovingDistance", b)
+	cos := LambdaCDM{H0: 70, Om0: 0.3, Ol0: 0.9}
+	benchmarkLambdaCDMDistance(cos.ComovingDistance, b)
 }


### PR DESCRIPTION
This CL modifies the LambdaCDM benchmarks to use method-closures instead
of reflect to call specific LambdaCDM methods.

The gains are not super impressive for all cases but this makes the
benchmarks somewhat more correct.

```
$> benchstat ref-LambdaCDM.txt new.txt
name                                    old time/op  new time/op  delta
LambdaCDMEN-4                           60.5µs ± 2%  60.6µs ± 1%     ~     (p=0.351 n=20+20)
LambdaCDMENdistance-4                   8.09ms ± 7%  0.18ms ± 1%  -97.80%  (p=0.000 n=19+20)
LambdaCDME-4                            6.41ns ± 1%  6.41ns ± 1%     ~     (p=0.486 n=19+20)
LambdaCDMEinv-4                         11.7ns ± 1%  11.8ns ± 3%   +0.63%  (p=0.014 n=19+20)
LambdaCDMComovingDistance-4              210µs ± 2%   206µs ± 1%   -1.96%  (p=0.000 n=20+19)
LambdaCDMComovingTransverseDistance-4    211µs ± 1%   207µs ± 1%   -1.59%  (p=0.000 n=19+19)
LambdaCDMLuminosityDistance-4            213µs ± 2%   207µs ± 1%   -2.93%  (p=0.000 n=19+20)
LambdaCDMLookbackTime-4                  214µs ± 1%   213µs ± 1%   -0.66%  (p=0.000 n=16+19)
LambdaCDMNComovingDistance-4             2.09s ± 0%   2.07s ± 1%   -1.41%  (p=0.000 n=16+20)
LambdaCDMNLuminosityDistance-4           2.09s ± 1%   2.07s ± 1%   -0.99%  (p=0.000 n=20+20)
LambdaCDMNE-4                           8.22ms ± 7%  0.18ms ± 1%  -97.84%  (p=0.000 n=20+20)
LambdaCDMComovingDistanceOM-4            939ns ±12%   161ns ± 1%  -82.85%  (p=0.000 n=20+20)
LambdaCDMLookbackTimeOM-4               1.32µs ± 9%  0.49µs ± 1%  -62.86%  (p=0.000 n=20+20)
LambdaCDMComovingDistanceFlat-4         1.42µs ± 7%  0.62µs ± 1%  -56.55%  (p=0.000 n=20+20)
LambdaCDMComovingDistancePositiveOk0-4   210µs ± 1%   207µs ± 2%   -1.39%  (p=0.000 n=20+20)
```