### PR TITLE
cosmo: remove calls to reflect in WACDM benchmarks

### DIFF
--- a/benchmark_wacdm_test.go
+++ b/benchmark_wacdm_test.go
@@ -1,13 +1,11 @@
 package cosmo
 
 import (
-	"reflect"
 	"testing"
 )
 
 func benchmarkWACDMEN(n int, b *testing.B) {
 	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2, WA: 2}
-
 	var z float64
 	zMax := 1.0
 	step := zMax / float64(n)
@@ -24,7 +22,8 @@ func BenchmarkWACDMEN(b *testing.B) {
 }
 
 func BenchmarkWACDMENdistance(b *testing.B) {
-	benchmarkWACDMNdistance(10000, "E", b)
+	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+	benchmarkWACDMNdistance(10000, cos.E, b)
 }
 
 func BenchmarkWACDME(b *testing.B) {
@@ -43,108 +42,78 @@ func BenchmarkWACDMEinv(b *testing.B) {
 	}
 }
 
-// benchmarkWACDMDistanceFlat is a helper function to be called by specific benchmarkWCDMs
-//   for an Omega_K == 0 cosmology
-func benchmarkWACDMDistanceFlat(distFunc string, b *testing.B) {
-	cos := WACDM{H0: 70, Om0: 0.3, Ol0: 0.7, W0: -1, WA: 0}
-	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
-	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
-	}
-}
-
-// benchmarkWCDMDistancePositiveOk0 is a helper function to be called by specific benchmarkWCDMs
-//   for an Omega_K > 0 cosmology
-func benchmarkWACDMDistancePositiveOk0(distFunc string, b *testing.B) {
-	cos := WACDM{H0: 70, Om0: 0.3, Ol0: 0.9, W0: -1, WA: 2}
-	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
-	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
-	}
-}
-
-// benchmarkWACDMDistanceOM is a helper function to be called by specific benchmarkWACDMs
-//   for an Omega_Lambda = 0 cosmology
-func benchmarkWACDMDistanceOM(distFunc string, b *testing.B) {
-	cos := WACDM{H0: 70, Om0: 0.3, Ol0: 0, W0: -1.2, WA: 2}
-	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
-	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
-	}
-}
-
 // benchmarkWACDMDistance is a helper function to be called by specific benchmarkWACDMs
-func benchmarkWACDMDistance(distFunc string, b *testing.B) {
-	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+func benchmarkWACDMDistance(f func(float64) float64, b *testing.B) {
 	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
 	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
+		f(z)
 	}
 }
 
 // benchmarkWACDMNdistance is a helper function to be called by specific benchmarkWACDMs
-func benchmarkWACDMNdistance(n int, distFunc string, b *testing.B) {
-	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
+func benchmarkWACDMNdistance(n int, f func(float64) float64, b *testing.B) {
 	var z float64
 	zMax := 1.0
 	step := zMax / float64(n)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
 			z = 0.001 + step*float64(j)
-			funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
+			f(z)
 		}
 	}
 }
 
 func BenchmarkWACDMComovingDistance(b *testing.B) {
-	benchmarkWACDMDistance("ComovingDistance", b)
+	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+	benchmarkWACDMDistance(cos.ComovingDistance, b)
 }
 
 func BenchmarkWACDMComovingTransverseDistance(b *testing.B) {
-	benchmarkWACDMDistance("ComovingTransverseDistance", b)
+	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+	benchmarkWACDMDistance(cos.ComovingTransverseDistance, b)
 }
 
 func BenchmarkWACDMLuminosityDistance(b *testing.B) {
-	benchmarkWACDMDistance("LuminosityDistance", b)
+	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+	benchmarkWACDMDistance(cos.LuminosityDistance, b)
 }
 
 func BenchmarkWACDMLookbackTime(b *testing.B) {
-	benchmarkWACDMDistance("LookbackTime", b)
+	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+	benchmarkWACDMDistance(cos.LookbackTime, b)
 }
 
 func BenchmarkWACDMNComovingDistance(b *testing.B) {
-	benchmarkWACDMNdistance(10000, "ComovingDistance", b)
+	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+	benchmarkWACDMNdistance(10000, cos.ComovingDistance, b)
 }
 
 func BenchmarkWACDMNLuminosityDistance(b *testing.B) {
-	benchmarkWACDMNdistance(10000, "LuminosityDistance", b)
+	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+	benchmarkWACDMNdistance(10000, cos.LuminosityDistance, b)
 }
 
 func BenchmarkWACDMNE(b *testing.B) {
-	benchmarkWACDMNdistance(10000, "E", b)
+	cos := WACDM{H0: 70, Om0: 0.2, Ol0: 0.7, W0: -1.2}
+	benchmarkWACDMNdistance(10000, cos.E, b)
 }
 
 func BenchmarkWACDMComovingDistanceOM(b *testing.B) {
-	benchmarkWACDMDistanceOM("ComovingDistance", b)
+	cos := WACDM{H0: 70, Om0: 0.3, Ol0: 0, W0: -1.2, WA: 2}
+	benchmarkWACDMDistance(cos.ComovingDistance, b)
 }
 
 func BenchmarkWACDMLookbackTimeOM(b *testing.B) {
-	benchmarkWACDMDistanceOM("LookbackTime", b)
+	cos := WACDM{H0: 70, Om0: 0.3, Ol0: 0, W0: -1.2, WA: 2}
+	benchmarkWACDMDistance(cos.LookbackTime, b)
 }
 
 func BenchmarkWACDMComovingDistanceFlat(b *testing.B) {
-	benchmarkWACDMDistanceFlat("ComovingDistance", b)
+	cos := WACDM{H0: 70, Om0: 0.3, Ol0: 0.7, W0: -1, WA: 0}
+	benchmarkWACDMDistance(cos.ComovingDistance, b)
 }
 
 func BenchmarkWACDMComovingDistancePositiveOk0(b *testing.B) {
-	benchmarkWACDMDistancePositiveOk0("ComovingDistance", b)
+	cos := WACDM{H0: 70, Om0: 0.3, Ol0: 0.9, W0: -1, WA: 2}
+	benchmarkWACDMDistance(cos.ComovingDistance, b)
 }


### PR DESCRIPTION
```
name                                old time/op  new time/op  delta
WACDMEN-4                           2.20ms ± 1%  2.20ms ± 1%     ~     (p=0.690 n=5+5)
WACDMENdistance-4                   9.83ms ± 7%  1.74ms ± 1%  -82.32%  (p=0.008 n=5+5)
WACDME-4                             205ns ± 0%   205ns ± 0%     ~     (all equal)
WACDMEinv-4                          229ns ± 1%   226ns ± 0%   -1.14%  (p=0.000 n=5+4)
WACDMComovingDistance-4              357µs ± 2%   367µs ± 1%   +2.87%  (p=0.008 n=5+5)
WACDMComovingTransverseDistance-4    369µs ± 1%   356µs ± 1%   -3.39%  (p=0.008 n=5+5)
WACDMLuminosityDistance-4            393µs ± 1%   412µs ± 1%   +4.80%  (p=0.008 n=5+5)
WACDMLookbackTime-4                  370µs ± 1%   363µs ± 1%   -1.82%  (p=0.008 n=5+5)
WACDMNComovingDistance-4             3.55s ± 0%   3.62s ± 0%   +2.03%  (p=0.008 n=5+5)
WACDMNLuminosityDistance-4           3.58s ± 1%   3.54s ± 0%   -1.01%  (p=0.008 n=5+5)
WACDMNE-4                           10.1ms ± 1%   1.7ms ± 1%  -82.68%  (p=0.008 n=5+5)
WACDMComovingDistanceOM-4            947ns ± 2%   156ns ± 1%  -83.53%  (p=0.008 n=5+5)
WACDMLookbackTimeOM-4               1.33µs ± 4%  0.49µs ± 1%  -63.26%  (p=0.008 n=5+5)
WACDMComovingDistanceFlat-4         1.52µs ± 3%  0.66µs ± 1%  -56.85%  (p=0.008 n=5+5)
WACDMComovingDistancePositiveOk0-4   337µs ± 1%   331µs ± 1%   -1.73%  (p=0.008 n=5+5)
```