### PR TITLE
cosmo: remove calls to reflect in FlatLCDM benchmarks

### DIFF
--- a/benchmark_flatlcdm_test.go
+++ b/benchmark_flatlcdm_test.go
@@ -1,13 +1,11 @@
 package cosmo
 
 import (
-	"reflect"
 	"testing"
 )
 
 func benchmarkFlatLCDMEN(n int, b *testing.B) {
 	cos := FlatLCDM{H0: 70, Om0: 0.27}
-
 	var z float64
 	zMax := 1.0
 	step := zMax / float64(n)
@@ -24,7 +22,8 @@ func BenchmarkFlatLCDMEN(b *testing.B) {
 }
 
 func BenchmarkFlatLCDMENdistance(b *testing.B) {
-	benchmarkFlatLCDMNdistance(10000, "E", b)
+	cos := FlatLCDM{H0: 70, Om0: 0.27}
+	benchmarkFlatLCDMNdistance(10000, cos.E, b)
 }
 
 func BenchmarkFlatLCDME(b *testing.B) {
@@ -44,55 +43,57 @@ func BenchmarkFlatLCDMEinv(b *testing.B) {
 }
 
 // benchmarkFlatLCDMDistance is a helper function to be called by specific benchmarkFlatLCDMs
-func benchmarkFlatLCDMDistance(distFunc string, b *testing.B) {
-	cos := FlatLCDM{H0: 70, Om0: 0.27}
+func benchmarkFlatLCDMDistance(f func(float64) float64, b *testing.B) {
 	z := 1.0
-
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
 	for i := 0; i < b.N; i++ {
-		funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
+		f(z)
 	}
 }
 
 // benchmarkFlatLCDMNdistance is a helper function to be called by specific benchmarkFlatLCDMs
-func benchmarkFlatLCDMNdistance(n int, distFunc string, b *testing.B) {
-	cos := FlatLCDM{H0: 70, Om0: 0.27}
-	funcToTest := reflect.ValueOf(&cos).MethodByName(distFunc)
+func benchmarkFlatLCDMNdistance(n int, f func(float64) float64, b *testing.B) {
 	var z float64
 	zMax := 1.0
 	step := zMax / float64(n)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < n; j++ {
 			z = 0.001 + step*float64(j)
-			funcToTest.Call([]reflect.Value{reflect.ValueOf(z)})
+			f(z)
 		}
 	}
 }
 
 func BenchmarkFlatLCDMComovingDistance(b *testing.B) {
-	benchmarkFlatLCDMDistance("ComovingDistance", b)
+	cos := FlatLCDM{H0: 70, Om0: 0.27}
+	benchmarkFlatLCDMDistance(cos.ComovingDistance, b)
 }
 
 func BenchmarkFlatLCDMComovingTransverseDistance(b *testing.B) {
-	benchmarkFlatLCDMDistance("ComovingTransverseDistance", b)
+	cos := FlatLCDM{H0: 70, Om0: 0.27}
+	benchmarkFlatLCDMDistance(cos.ComovingTransverseDistance, b)
 }
 
 func BenchmarkFlatLCDMLuminosityDistance(b *testing.B) {
-	benchmarkFlatLCDMDistance("LuminosityDistance", b)
+	cos := FlatLCDM{H0: 70, Om0: 0.27}
+	benchmarkFlatLCDMDistance(cos.LuminosityDistance, b)
 }
 
 func BenchmarkFlatLCDMLookbackTime(b *testing.B) {
-	benchmarkFlatLCDMDistance("LookbackTime", b)
+	cos := FlatLCDM{H0: 70, Om0: 0.27}
+	benchmarkFlatLCDMDistance(cos.LookbackTime, b)
 }
 
 func BenchmarkFlatLCDMNComovingDistance(b *testing.B) {
-	benchmarkFlatLCDMNdistance(10000, "ComovingDistance", b)
+	cos := FlatLCDM{H0: 70, Om0: 0.27}
+	benchmarkFlatLCDMNdistance(10000, cos.ComovingDistance, b)
 }
 
 func BenchmarkFlatLCDMNLuminosityDistance(b *testing.B) {
-	benchmarkFlatLCDMNdistance(10000, "LuminosityDistance", b)
+	cos := FlatLCDM{H0: 70, Om0: 0.27}
+	benchmarkFlatLCDMNdistance(10000, cos.LuminosityDistance, b)
 }
 
 func BenchmarkFlatLCDMNE(b *testing.B) {
-	benchmarkFlatLCDMNdistance(10000, "E", b)
+	cos := FlatLCDM{H0: 70, Om0: 0.27}
+	benchmarkFlatLCDMNdistance(10000, cos.E, b)
 }


### PR DESCRIPTION
This CL removes all the calls to reflect in the FlatLCDM benchmarks.

```
$> benchstat ref-flatlcdm.txt new.txt
name                                  old time/op  new time/op  delta
FlatLCDMEN-4                          60.6µs ± 1%  60.6µs ± 2%     ~     (p=0.825 n=20+20)
FlatLCDMENdistance-4                  7.98ms ± 7%  0.17ms ± 1%  -97.88%  (p=0.000 n=20+20)
FlatLCDME-4                           6.42ns ± 2%  6.41ns ± 1%     ~     (p=0.572 n=20+20)
FlatLCDMEinv-4                        11.8ns ± 1%  11.7ns ± 0%   -0.47%  (p=0.003 n=20+16)
FlatLCDMComovingDistance-4            1.45µs ± 8%  0.60µs ± 1%  -58.83%  (p=0.000 n=20+20)
FlatLCDMComovingTransverseDistance-4  1.46µs ± 8%  0.61µs ± 1%  -58.52%  (p=0.000 n=20+18)
FlatLCDMLuminosityDistance-4          1.43µs ± 5%  0.62µs ± 2%  -56.79%  (p=0.000 n=20+20)
FlatLCDMLookbackTime-4                 240µs ± 1%   212µs ± 1%  -11.58%  (p=0.000 n=20+20)
FlatLCDMNComovingDistance-4           14.2ms ± 6%   6.2ms ± 1%  -56.57%  (p=0.000 n=19+20)
FlatLCDMNLuminosityDistance-4         14.5ms ± 7%   6.4ms ± 1%  -55.95%  (p=0.000 n=19+20)
FlatLCDMNE-4                          8.22ms ± 7%  0.17ms ± 1%  -97.94%  (p=0.000 n=20+20)
```